### PR TITLE
docs: study Unity upgrade and networking options

### DIFF
--- a/UPGRADE_NETWORKING_STUDY.md
+++ b/UPGRADE_NETWORKING_STUDY.md
@@ -7,6 +7,7 @@ Study focused on updating Unity/packages and evaluating whether to keep Mirror o
 Repository inspection shows:
 
 - Unity Editor: `2021.3.4f1`.
+- Target product requirement: browser/WebGL build.
 - Active build scene: `Assets/Scenes/MONGLICLIENT.unity`.
 - Disabled/prototype scenes still present in build settings: `GameScene`, `CharacterControllerTest`, `MONGLISERVER`, `Empty`, Input System sample.
 - Package versions:
@@ -18,16 +19,32 @@ Repository inspection shows:
 - Networking appears to use Mirror embedded directly under `Assets/Mirror`, not as a clean package dependency.
 - Some Mirror core files have project-local modifications in history/current comparison.
 
+## Critical WebGL/browser constraint
+
+Because the game targets browser/WebGL, the networking stack must support browser-safe transports.
+
+In practice:
+
+- Do not assume normal UDP sockets are available from the browser client.
+- Do not assume raw TCP sockets are available from the browser client.
+- Prefer `WSS` / secure WebSocket for production browser builds.
+- HTTP/REST is fine for login, inventory, matchmaking and persistence, but not ideal for high-frequency gameplay state.
+- WebRTC DataChannels can be interesting for low-latency browser networking, but they add signaling, NAT traversal and server/relay complexity.
+
+This means every networking candidate must be evaluated by transport, not only by API.
+
 ## Main conclusion
 
 Do **not** upgrade Unity, packages and networking stack in the same step.
+
+Also: do **not** choose a new networking library unless its WebGL transport story is proven with a running prototype.
 
 Recommended approach:
 
 1. Stabilize the current project.
 2. Upgrade Unity/packages in a dedicated compatibility branch.
-3. Build a small isolated networking prototype with the candidate stack.
-4. Migrate gameplay networking only after validating feature parity.
+3. Build a small isolated WebGL networking prototype with the candidate stack.
+4. Migrate gameplay networking only after validating feature parity in browser.
 
 The highest risk is not the Unity version itself. The highest risk is that gameplay, animation, ownership and network synchronization are currently coupled and partially undocumented.
 
@@ -44,6 +61,7 @@ Actions:
 - Fix compile issues.
 - Update only minor package versions compatible with Unity 2021.
 - Keep Mirror as-is initially.
+- Validate a WebGL build early.
 
 Pros:
 
@@ -67,7 +85,7 @@ Actions:
 - Duplicate project / branch.
 - Open with Unity 6 LTS.
 - Update packages.
-- Validate shaders, Input System, Addressables, UI, Mirror and build targets.
+- Validate shaders, Input System, Addressables, UI, Mirror and WebGL build targets.
 
 Pros:
 
@@ -80,10 +98,11 @@ Cons:
 - Mirror compatibility must be validated.
 - Asset/shader/package issues likely.
 - Possible API breaks in old third-party assets.
+- WebGL build/runtime behavior must be retested, not assumed.
 
 Recommended after the conservative baseline passes.
 
-## Networking options
+## Networking options for browser/WebGL
 
 ### Option A - Keep Mirror, but clean integration
 
@@ -92,8 +111,16 @@ Current situation:
 - Mirror is embedded in `Assets/Mirror`.
 - Some Mirror core files appear modified directly.
 
+WebGL compatibility assessment:
+
+- Mirror can be viable for browser builds if using a WebSocket-compatible transport.
+- Do not use UDP/KCP transport for the WebGL client.
+- Native server can run outside the browser, but the browser client should connect through WebSocket/WSS.
+
 Recommended if keeping Mirror:
 
+- Confirm which transport is currently configured in the active scene/network manager.
+- Switch/standardize browser builds around WebSocket/WSS transport.
 - Move Mirror to a managed package or clearly isolate it under `_ThirdParty`.
 - Avoid modifying Mirror core files directly.
 - Add `PATCHES.md` documenting any unavoidable changes.
@@ -104,16 +131,18 @@ Pros:
 - Lowest migration cost.
 - Existing player/spawn/sync logic probably already depends on it.
 - Good short-term path to preserve current functionality.
+- Most likely path to keep browser functionality with minimal rewrite.
 
 Cons:
 
 - Current integration is messy.
 - Local vendor modifications make upgrades risky.
 - Future Mirror upgrades may be painful.
+- WebSocket may add more overhead/latency than UDP-based transports.
 
 Best use case:
 
-- Keep the current game working while cleaning architecture.
+- Keep the current browser game working while cleaning architecture.
 
 ### Option B - Migrate to Unity Netcode for GameObjects
 
@@ -123,6 +152,12 @@ What it gives:
 - Integrated with Unity Transport and Unity Multiplayer Services.
 - Current Netcode for GameObjects 2.x targets modern Unity versions.
 - Supports GameObject/world-state synchronization, host/client-server workflows and newer distributed authority concepts.
+
+WebGL compatibility assessment:
+
+- Potentially viable for browser only if the chosen Unity Transport configuration supports WebSocket for WebGL.
+- Should not be selected until a Unity WebGL build can connect to a real server through WebSocket/WSS.
+- Treat this as a Unity 6 modernization prototype, not as a direct replacement in the current project.
 
 Pros:
 
@@ -135,10 +170,11 @@ Cons:
 - Not a drop-in Mirror replacement.
 - Requires rewriting `NetworkBehaviour`, RPCs, SyncVars/NetworkVariables, spawning, authority checks and transform synchronization.
 - Latest NGO direction is coupled to newer Unity versions.
+- Browser transport compatibility must be validated very early.
 
 Best use case:
 
-- Strategic modernization if the project is going to continue evolving seriously.
+- Strategic modernization if the project is going to continue evolving seriously and Unity ecosystem alignment matters.
 
 ### Option C - Migrate to Fish-Networking
 
@@ -146,8 +182,13 @@ What it gives:
 
 - Free Unity networking solution.
 - Server-authoritative by design but allows host mode.
-- No CCU cap/paywall according to its positioning.
 - Broad topology support through transports.
+
+WebGL compatibility assessment:
+
+- Do not assume browser compatibility from the high-level framework.
+- It is only viable if the selected Fish-Networking transport supports WebSocket/WebGL properly.
+- Needs a dedicated browser prototype before committing.
 
 Pros:
 
@@ -159,28 +200,45 @@ Cons:
 
 - Still requires a real migration.
 - Smaller ecosystem than Unity official tooling.
+- Transport choice is critical for WebGL.
 - Needs a dedicated prototype before committing.
 
 Best use case:
 
-- Robust server-authoritative architecture without depending heavily on Unity Gaming Services.
+- Robust server-authoritative architecture without depending heavily on Unity Gaming Services, if WebGL transport validation passes.
 
 ### Option D - Photon Fusion
 
 Worth evaluating separately for production multiplayer, especially if we want hosted/session services, prediction-oriented gameplay and commercial tooling.
 
-However, this is a product/platform decision because it introduces vendor pricing, cloud dependency and a different architecture mindset.
+WebGL compatibility assessment:
 
-## Recommended decision
+- Must be checked against current Photon Fusion WebGL support, pricing and deployment requirements.
+- If browser support is first-class, it can be attractive, but it becomes a vendor/platform decision.
 
-My recommendation for this project:
+Cons:
 
-1. **Short term:** keep Mirror, clean current architecture and document authority/spawning.
-2. **Medium term:** upgrade Unity in stages.
-3. **Strategic branch:** prototype Unity Netcode for GameObjects and Fish-Networking in parallel using the same minimal gameplay scenario.
-4. Choose the final networking system based on prototype results, not theory.
+- Pricing/vendor dependency.
+- Different architecture mindset.
+- Migration effort is still high.
 
-I would not migrate networking before we have a clean `PlayerRuntimeMap`.
+## Recommended decision after considering WebGL
+
+The browser requirement changes the recommendation:
+
+1. **Short term:** keep Mirror if it can run with a WebSocket/WSS transport in the current project.
+2. **Medium term:** clean Mirror integration and document the exact browser transport setup.
+3. **Strategic branch:** prototype Netcode for GameObjects and Fish-Networking only if they can prove WebGL/WSS connectivity.
+4. Do not prioritize any UDP-first stack for the WebGL client.
+
+Current preference with browser target:
+
+```text
+1. Mirror + WebSocket/WSS transport, cleaned and documented.
+2. Unity NGO only after WebGL WebSocket prototype succeeds.
+3. Fish-Networking only after WebGL transport prototype succeeds.
+4. Photon Fusion only if vendor dependency/pricing is acceptable and WebGL support is confirmed.
+```
 
 ## Minimum functionality to preserve
 
@@ -197,9 +255,11 @@ Before changing networking, document and test:
 - Audio behavior local vs remote.
 - Scene loading.
 - Disconnect/reconnect behavior.
-- WebGL fullscreen/build behavior if still relevant.
+- WebGL fullscreen/build behavior.
+- Browser connection through `wss://`.
+- Server hosting behind HTTPS/WSS reverse proxy if needed.
 
-## Prototype plan
+## WebGL networking prototype plan
 
 Create a separate small scene, not touching the current gameplay scene:
 
@@ -209,36 +269,36 @@ Assets/_Project/Scenes/NetworkingPrototype.unity
 
 Prototype requirements:
 
+- Build as WebGL.
+- Host server as native standalone/headless, not inside browser.
+- Browser client connects through `wss://`.
 - Spawn 2 players.
 - Move local player.
 - Sync remote transform smoothly.
 - Sync velocity/state for animation.
 - Spawn/despawn a simple network object.
-- Test host/client and dedicated server if relevant.
-- Measure code complexity and migration friction.
+- Test reconnect/disconnect.
+- Measure latency and jitter from browser.
+- Confirm it works behind the intended deployment environment.
 
-Implement the same prototype twice:
-
-```text
-Prototype_NGO
-Prototype_FishNet
-```
-
-Optionally a third baseline:
+Implement the same prototype with:
 
 ```text
-Prototype_MirrorClean
+Prototype_MirrorWebSocket
+Prototype_NGO_WebSocket
+Prototype_FishNet_WebSocket
 ```
 
 Decision criteria:
 
-- Ease of migration from current code.
-- Authority model clarity.
-- WebGL/desktop compatibility.
-- Server hosting options.
-- Debuggability.
-- Amount of glue code required.
-- Long-term maintainability.
+- Does WebGL build compile?
+- Does browser connect through WSS?
+- Is server hosting simple?
+- Does reconnect work?
+- Is latency acceptable?
+- Can it handle current player movement/animation sync?
+- How much glue code is needed?
+- How painful is migration from current code?
 
 ## Proposed branch roadmap
 
@@ -249,45 +309,56 @@ Purpose:
 - Open with current Unity.
 - Confirm compile status.
 - Document runtime map.
+- Confirm current WebGL build status.
 - No package/network migration yet.
 
 Deliverable:
 
 ```text
 PLAYER_RUNTIME_MAP.md
+WEBGL_BASELINE_NOTES.md
 ```
 
-### Branch 2 - `upgrade/unity-2021-latest-lts`
+### Branch 2 - `networking/mirror-websocket-baseline`
+
+Purpose:
+
+- Identify and standardize Mirror WebSocket/WSS transport.
+- Confirm browser client connection.
+- Document server deployment notes.
+
+### Branch 3 - `upgrade/unity-2021-latest-lts`
 
 Purpose:
 
 - Upgrade only within Unity 2021 LTS patch line.
-- Keep Mirror.
+- Keep Mirror WebSocket.
 - Fix compile/import warnings.
+- Validate WebGL build.
 
-### Branch 3 - `upgrade/unity-6-compatibility`
+### Branch 4 - `upgrade/unity-6-compatibility`
 
 Purpose:
 
 - Test Unity 6 compatibility.
 - Do not migrate networking yet.
-- Identify package/shader/API breaks.
+- Identify package/shader/API/WebGL breaks.
 
-### Branch 4 - `prototype/networking-ngo`
-
-Purpose:
-
-- Small isolated prototype using Netcode for GameObjects.
-- Validate spawn/authority/sync.
-
-### Branch 5 - `prototype/networking-fishnet`
+### Branch 5 - `prototype/networking-ngo-webgl`
 
 Purpose:
 
-- Same isolated prototype using Fish-Networking.
-- Compare complexity and stability.
+- Isolated WebGL prototype using Netcode for GameObjects.
+- Validate browser WSS connectivity, spawn, authority and sync.
 
-### Branch 6 - `refactor/network-abstraction`
+### Branch 6 - `prototype/networking-fishnet-webgl`
+
+Purpose:
+
+- Isolated WebGL prototype using Fish-Networking.
+- Validate browser WSS connectivity, spawn, authority and sync.
+
+### Branch 7 - `refactor/network-abstraction`
 
 Purpose:
 
@@ -330,18 +401,20 @@ The networking stack should become an implementation detail, not something sprea
 
 ## Final recommendation
 
-Best practical route:
+Best practical route for a browser game:
 
 1. Keep Mirror for now.
-2. Fix compile/runtime safety.
-3. Document active player prefab and authority model.
-4. Upgrade Unity conservatively.
-5. Test Unity 6 separately.
-6. Prototype NGO and FishNet separately.
-7. Migrate only if one prototype clearly beats cleaned Mirror.
+2. Confirm current WebGL build and current transport.
+3. Move toward Mirror + WebSocket/WSS as baseline.
+4. Fix compile/runtime safety.
+5. Document active player prefab and authority model.
+6. Upgrade Unity conservatively.
+7. Test Unity 6 separately.
+8. Prototype NGO/FishNet only through real WebGL/WSS builds.
+9. Migrate only if one prototype clearly beats cleaned Mirror.
 
 Current preference:
 
-- Small/experimental multiplayer game: **clean Mirror first**.
-- Serious long-term Unity project: **Unity 6 + Netcode for GameObjects** is worth prototyping.
-- Strong authoritative networking without Unity service dependency: **Fish-Networking** is the strongest alternative to prototype.
+- Browser-first + minimal risk: **clean Mirror + WebSocket/WSS**.
+- Browser-first + long-term Unity ecosystem: **Unity 6 + NGO**, but only after WebGL prototype.
+- Browser-first + stronger authoritative networking: **Fish-Networking**, but only if WebGL transport is proven.

--- a/UPGRADE_NETWORKING_STUDY.md
+++ b/UPGRADE_NETWORKING_STUDY.md
@@ -1,0 +1,347 @@
+# Upgrade and networking study - ElTesoroDeMongli
+
+Study focused on updating Unity/packages and evaluating whether to keep Mirror or migrate to a newer networking stack while preserving current functionality.
+
+## Current project baseline
+
+Repository inspection shows:
+
+- Unity Editor: `2021.3.4f1`.
+- Active build scene: `Assets/Scenes/MONGLICLIENT.unity`.
+- Disabled/prototype scenes still present in build settings: `GameScene`, `CharacterControllerTest`, `MONGLISERVER`, `Empty`, Input System sample.
+- Package versions:
+  - Addressables `1.19.19`
+  - Cinemachine `2.9.5`
+  - Input System `1.4.2`
+  - TextMeshPro `3.0.6`
+  - Timeline `1.6.4`
+- Networking appears to use Mirror embedded directly under `Assets/Mirror`, not as a clean package dependency.
+- Some Mirror core files have project-local modifications in history/current comparison.
+
+## Main conclusion
+
+Do **not** upgrade Unity, packages and networking stack in the same step.
+
+Recommended approach:
+
+1. Stabilize the current project.
+2. Upgrade Unity/packages in a dedicated compatibility branch.
+3. Build a small isolated networking prototype with the candidate stack.
+4. Migrate gameplay networking only after validating feature parity.
+
+The highest risk is not the Unity version itself. The highest risk is that gameplay, animation, ownership and network synchronization are currently coupled and partially undocumented.
+
+## Unity upgrade options
+
+### Option 1 - Conservative patch upgrade inside 2021 LTS
+
+Goal: lowest-risk modernization.
+
+Actions:
+
+- Open the project with a newer Unity 2021.3 LTS patch.
+- Let Unity reimport.
+- Fix compile issues.
+- Update only minor package versions compatible with Unity 2021.
+- Keep Mirror as-is initially.
+
+Pros:
+
+- Lowest risk.
+- Best first step to clean warnings and package drift.
+- Lets us validate the current game before bigger changes.
+
+Cons:
+
+- Does not unlock the latest Unity networking ecosystem.
+- Still leaves old architecture/networking issues.
+
+Recommended as first technical step.
+
+### Option 2 - Upgrade to Unity 6 LTS
+
+Goal: modern platform base.
+
+Actions:
+
+- Duplicate project / branch.
+- Open with Unity 6 LTS.
+- Update packages.
+- Validate shaders, Input System, Addressables, UI, Mirror and build targets.
+
+Pros:
+
+- Long-term modern base.
+- Better future compatibility with current Unity tooling and multiplayer services.
+
+Cons:
+
+- Higher migration risk.
+- Mirror compatibility must be validated.
+- Asset/shader/package issues likely.
+- Possible API breaks in old third-party assets.
+
+Recommended after the conservative baseline passes.
+
+## Networking options
+
+### Option A - Keep Mirror, but clean integration
+
+Current situation:
+
+- Mirror is embedded in `Assets/Mirror`.
+- Some Mirror core files appear modified directly.
+
+Recommended if keeping Mirror:
+
+- Move Mirror to a managed package or clearly isolate it under `_ThirdParty`.
+- Avoid modifying Mirror core files directly.
+- Add `PATCHES.md` documenting any unavoidable changes.
+- Wrap Mirror-specific logic in project-level adapters.
+
+Pros:
+
+- Lowest migration cost.
+- Existing player/spawn/sync logic probably already depends on it.
+- Good short-term path to preserve current functionality.
+
+Cons:
+
+- Current integration is messy.
+- Local vendor modifications make upgrades risky.
+- Future Mirror upgrades may be painful.
+
+Best use case:
+
+- Keep the current game working while cleaning architecture.
+
+### Option B - Migrate to Unity Netcode for GameObjects
+
+What it gives:
+
+- Official Unity networking stack.
+- Integrated with Unity Transport and Unity Multiplayer Services.
+- Current Netcode for GameObjects 2.x targets modern Unity versions.
+- Supports GameObject/world-state synchronization, host/client-server workflows and newer distributed authority concepts.
+
+Pros:
+
+- Official Unity path.
+- Better alignment with Unity Relay, Lobby, Matchmaker and future Unity tooling.
+- Good for a project we want to maintain long-term inside Unity ecosystem.
+
+Cons:
+
+- Not a drop-in Mirror replacement.
+- Requires rewriting `NetworkBehaviour`, RPCs, SyncVars/NetworkVariables, spawning, authority checks and transform synchronization.
+- Latest NGO direction is coupled to newer Unity versions.
+
+Best use case:
+
+- Strategic modernization if the project is going to continue evolving seriously.
+
+### Option C - Migrate to Fish-Networking
+
+What it gives:
+
+- Free Unity networking solution.
+- Server-authoritative by design but allows host mode.
+- No CCU cap/paywall according to its positioning.
+- Broad topology support through transports.
+
+Pros:
+
+- More feature-rich than many free options.
+- Good if we want serious networking without Unity service lock-in.
+- Potentially better for authoritative gameplay than ad-hoc Mirror usage.
+
+Cons:
+
+- Still requires a real migration.
+- Smaller ecosystem than Unity official tooling.
+- Needs a dedicated prototype before committing.
+
+Best use case:
+
+- Robust server-authoritative architecture without depending heavily on Unity Gaming Services.
+
+### Option D - Photon Fusion
+
+Worth evaluating separately for production multiplayer, especially if we want hosted/session services, prediction-oriented gameplay and commercial tooling.
+
+However, this is a product/platform decision because it introduces vendor pricing, cloud dependency and a different architecture mindset.
+
+## Recommended decision
+
+My recommendation for this project:
+
+1. **Short term:** keep Mirror, clean current architecture and document authority/spawning.
+2. **Medium term:** upgrade Unity in stages.
+3. **Strategic branch:** prototype Unity Netcode for GameObjects and Fish-Networking in parallel using the same minimal gameplay scenario.
+4. Choose the final networking system based on prototype results, not theory.
+
+I would not migrate networking before we have a clean `PlayerRuntimeMap`.
+
+## Minimum functionality to preserve
+
+Before changing networking, document and test:
+
+- Login/API flow.
+- Start client/server/host flow.
+- Player spawn.
+- Local player ownership.
+- Remote player visibility.
+- Movement synchronization.
+- Animation synchronization.
+- Jump/land/attack animation events.
+- Audio behavior local vs remote.
+- Scene loading.
+- Disconnect/reconnect behavior.
+- WebGL fullscreen/build behavior if still relevant.
+
+## Prototype plan
+
+Create a separate small scene, not touching the current gameplay scene:
+
+```text
+Assets/_Project/Scenes/NetworkingPrototype.unity
+```
+
+Prototype requirements:
+
+- Spawn 2 players.
+- Move local player.
+- Sync remote transform smoothly.
+- Sync velocity/state for animation.
+- Spawn/despawn a simple network object.
+- Test host/client and dedicated server if relevant.
+- Measure code complexity and migration friction.
+
+Implement the same prototype twice:
+
+```text
+Prototype_NGO
+Prototype_FishNet
+```
+
+Optionally a third baseline:
+
+```text
+Prototype_MirrorClean
+```
+
+Decision criteria:
+
+- Ease of migration from current code.
+- Authority model clarity.
+- WebGL/desktop compatibility.
+- Server hosting options.
+- Debuggability.
+- Amount of glue code required.
+- Long-term maintainability.
+
+## Proposed branch roadmap
+
+### Branch 1 - `upgrade/current-baseline-validation`
+
+Purpose:
+
+- Open with current Unity.
+- Confirm compile status.
+- Document runtime map.
+- No package/network migration yet.
+
+Deliverable:
+
+```text
+PLAYER_RUNTIME_MAP.md
+```
+
+### Branch 2 - `upgrade/unity-2021-latest-lts`
+
+Purpose:
+
+- Upgrade only within Unity 2021 LTS patch line.
+- Keep Mirror.
+- Fix compile/import warnings.
+
+### Branch 3 - `upgrade/unity-6-compatibility`
+
+Purpose:
+
+- Test Unity 6 compatibility.
+- Do not migrate networking yet.
+- Identify package/shader/API breaks.
+
+### Branch 4 - `prototype/networking-ngo`
+
+Purpose:
+
+- Small isolated prototype using Netcode for GameObjects.
+- Validate spawn/authority/sync.
+
+### Branch 5 - `prototype/networking-fishnet`
+
+Purpose:
+
+- Same isolated prototype using Fish-Networking.
+- Compare complexity and stability.
+
+### Branch 6 - `refactor/network-abstraction`
+
+Purpose:
+
+- Introduce project-level networking interfaces before migrating gameplay.
+
+Possible interfaces:
+
+```csharp
+public interface INetworkPlayerIdentity
+{
+    bool IsLocalPlayer { get; }
+    bool IsOwner { get; }
+    bool IsServer { get; }
+    ulong NetworkId { get; }
+}
+
+public interface INetworkSpawnService
+{
+    void SpawnPlayer(object connectionContext);
+    void DespawnPlayer(ulong networkId);
+}
+```
+
+## Refactor needed before migration
+
+Before changing networking stack, clean these layers:
+
+```text
+Input -> Movement -> Gameplay State -> Animation/Audio Presentation
+                    -> Network Sync
+```
+
+Avoid:
+
+```text
+Movement <-> Network <-> Animation <-> UI <-> Input
+```
+
+The networking stack should become an implementation detail, not something spread across every gameplay script.
+
+## Final recommendation
+
+Best practical route:
+
+1. Keep Mirror for now.
+2. Fix compile/runtime safety.
+3. Document active player prefab and authority model.
+4. Upgrade Unity conservatively.
+5. Test Unity 6 separately.
+6. Prototype NGO and FishNet separately.
+7. Migrate only if one prototype clearly beats cleaned Mirror.
+
+Current preference:
+
+- Small/experimental multiplayer game: **clean Mirror first**.
+- Serious long-term Unity project: **Unity 6 + Netcode for GameObjects** is worth prototyping.
+- Strong authoritative networking without Unity service dependency: **Fish-Networking** is the strongest alternative to prototype.

--- a/WEBGL_MOBILE_COMPATIBILITY_CHECKLIST.md
+++ b/WEBGL_MOBILE_COMPATIBILITY_CHECKLIST.md
@@ -1,0 +1,311 @@
+# WebGL mobile/browser compatibility checklist
+
+Checklist before manual testing of the browser/WebGL version.
+
+## Why this matters
+
+The project targets browser/WebGL, including desktop, Android and iOS. Browser support is not only about rendering WebGL; the real risks are:
+
+- WebAssembly memory limits on mobile browsers.
+- iOS Safari/WebKit behavior.
+- Touch input and fullscreen restrictions.
+- Audio unlock restrictions.
+- WebSocket/WSS networking requirements.
+- HTTPS/CORS/compression/server headers.
+- Asset size and loading time.
+
+## Important iOS note
+
+On iOS/iPadOS, do not treat Safari, Chrome and Firefox as fully different browser engines. In practice, iOS browsers are WebKit-based. Testing Chrome iOS and Firefox iOS is still useful, but the main rendering/runtime behavior will be close to Safari/WebKit.
+
+This means that if something breaks in Safari iOS, there is a significant chance it also breaks in Chrome iOS and Firefox iOS.
+
+## Minimum test matrix
+
+### Desktop
+
+- Windows + Chrome
+- Windows + Edge
+- Windows + Firefox
+- macOS + Safari
+- macOS + Chrome
+
+### Android
+
+- Android + Chrome
+- Android + Firefox
+- Android + Samsung Internet, if available
+
+### iOS / iPadOS
+
+- iPhone + Safari
+- iPhone + Chrome
+- iPad + Safari
+- iPad + Chrome
+
+## Device classes
+
+Try to cover at least:
+
+- Low/mid Android phone.
+- Recent Android phone.
+- Older iPhone still in expected user range.
+- Recent iPhone.
+- iPad if tablet support matters.
+
+## Browser feature checks
+
+Before launching the Unity content, add or use a simple HTML/JS diagnostics panel that reports:
+
+```text
+User Agent
+Platform
+Device pixel ratio
+Screen size
+WebGL 1 support
+WebGL 2 support
+WebAssembly support
+WebSocket support
+AudioContext support
+Pointer Events support
+Touch Events support
+Fullscreen API support
+IndexedDB/localStorage support
+```
+
+Recommended outcome:
+
+- If WebGL is missing, show a friendly unsupported browser message.
+- If WebAssembly is missing, show a friendly unsupported browser message.
+- If WebGL 2 is missing, either fallback to WebGL 1 or show a clear warning.
+
+## Unity build settings to review
+
+### Player settings
+
+Check in Unity WebGL Player Settings:
+
+- Compression format.
+- Decompression fallback.
+- Memory size / memory growth behavior.
+- WebGL 1/2 graphics API support depending on Unity version.
+- Data caching.
+- Exceptions setting.
+- Managed stripping level.
+- Code optimization mode.
+- Development build for diagnostics.
+
+### Recommended test setup
+
+For early compatibility testing:
+
+- Create a Development Build.
+- Enable visible logging to browser console.
+- Keep compression simple until server headers are verified.
+- Test without aggressive stripping first.
+- Add a version/build label visible on screen.
+
+For production:
+
+- Use Brotli or gzip only if the server is correctly configured.
+- Serve via HTTPS.
+- Use WSS for networking if the page is HTTPS.
+- Validate cache headers.
+
+## Server/deployment checks
+
+For Unity WebGL hosting, verify:
+
+- Correct MIME types for `.wasm`, `.data`, `.js`, `.symbols`, `.br`, `.gz`.
+- Correct `Content-Encoding` headers for compressed builds.
+- HTTPS enabled.
+- WSS endpoint enabled if multiplayer is used.
+- CORS configured if API/game server uses a different domain.
+- Reverse proxy timeout settings do not kill WebSocket connections.
+- Mobile network access tested, not only local Wi-Fi.
+
+## Networking checks
+
+Because browser clients cannot use normal raw TCP/UDP sockets like native apps, the WebGL client should use browser-safe transport:
+
+- Prefer WebSocket/WSS for Mirror or equivalent high-level networking.
+- Do not use KCP/UDP for the WebGL client.
+- If using HTTPS, use `wss://`, not `ws://`.
+- Confirm reconnect behavior after mobile sleep/background.
+- Confirm disconnect behavior when tab is closed or refreshed.
+- Confirm server cleans ghost players.
+
+## iOS-specific risks
+
+### 1. Memory pressure
+
+Unity WebGL builds can fail on iOS Safari if memory usage or initial asset load is too high.
+
+Mitigation:
+
+- Keep initial scene tiny.
+- Avoid loading all assets at startup.
+- Use Addressables/asset streaming carefully.
+- Reduce texture sizes.
+- Prefer compressed textures suitable for WebGL/mobile.
+- Avoid huge animation clips in initial load.
+- Avoid unnecessary duplicated assets.
+
+### 2. Audio restrictions
+
+Mobile browsers often require a user gesture before audio can start.
+
+Mitigation:
+
+- Start audio only after a first tap/click.
+- Add a clear “Tap to start” screen.
+- Initialize AudioContext after user interaction.
+
+### 3. Fullscreen restrictions
+
+Fullscreen behavior is inconsistent on iOS, especially iPhone Safari.
+
+Mitigation:
+
+- Do not make gameplay depend on true fullscreen.
+- Provide responsive canvas layout.
+- Hide browser UI as much as possible, but assume it may remain visible.
+- Test orientation changes.
+
+### 4. Touch input
+
+Mouse assumptions break on mobile.
+
+Mitigation:
+
+- Use pointer/touch abstraction.
+- Avoid right-click/middle-click requirements.
+- Ensure virtual joystick/buttons scale correctly.
+- Test multi-touch.
+- Prevent unwanted page scroll/zoom during gameplay.
+
+### 5. Background/sleep
+
+Mobile browsers pause or throttle tabs aggressively.
+
+Mitigation:
+
+- Handle visibility change from JS if needed.
+- Pause gameplay/network heartbeat cleanly.
+- Reconnect or resync after returning.
+
+## Android-specific risks
+
+- Different GPU/driver behavior between devices.
+- Some browsers/devices may blacklist WebGL features.
+- Memory can still be tight on low/mid devices.
+- Chrome Android and Samsung Internet may behave differently.
+- Address bar resizing can alter viewport height.
+
+## Suggested pre-test tasks
+
+### Task 1 - Add browser diagnostics page/panel
+
+Add a lightweight preloader panel before Unity starts or as a separate `diagnostics.html`.
+
+It should report browser features and show clear pass/warn/fail results.
+
+### Task 2 - Add visible build info
+
+Show on screen:
+
+```text
+Build version
+Commit hash
+Unity version
+Environment: local/staging/production
+Server URL
+Transport: ws/wss
+```
+
+### Task 3 - Add mobile-safe start screen
+
+Before loading/starting gameplay:
+
+```text
+Tap to start
+```
+
+This unlocks audio and avoids autoplay issues.
+
+### Task 4 - Add WebGL error overlay
+
+Catch and display:
+
+- WebGL unsupported.
+- WebAssembly unsupported.
+- WebSocket connection failed.
+- API login failed.
+- Asset load failed.
+
+### Task 5 - Create a tiny WebGL smoke test scene
+
+A minimal scene should test only:
+
+- Unity starts.
+- Input works.
+- Audio unlock works.
+- WebSocket connects.
+- One local object moves.
+- One network echo/roundtrip works.
+
+This scene should load faster than the real game and help isolate browser problems.
+
+## Manual test script
+
+For each device/browser:
+
+1. Open page.
+2. Confirm diagnostics pass.
+3. Tap start.
+4. Confirm Unity loads.
+5. Confirm no browser console fatal errors.
+6. Login/API call works.
+7. Connect to server through WSS.
+8. Spawn player.
+9. Move player.
+10. Confirm remote player sync from another browser.
+11. Trigger jump/animation/audio.
+12. Rotate device.
+13. Background app/tab for 30 seconds.
+14. Return to game.
+15. Confirm reconnect/resync or graceful disconnect.
+16. Refresh page.
+17. Confirm old player is cleaned from server.
+
+## Pass/fail criteria
+
+### Minimum acceptable
+
+- Game loads on desktop Chrome/Edge/Firefox and Android Chrome.
+- Game loads on iOS Safari on at least one recent iPhone.
+- Login works.
+- WebSocket/WSS connects.
+- Player spawns and moves.
+- Remote player visible.
+- No fatal memory crash during first 5 minutes.
+
+### Ideal
+
+- Works on iOS Safari, Chrome iOS and iPad Safari.
+- Handles tab background/return.
+- Handles refresh/disconnect cleanly.
+- Initial load below acceptable size/time target.
+- No duplicated audio/network players.
+
+## Recommendation before deeper networking migration
+
+Do this before testing NGO/FishNet/Photon:
+
+1. Create diagnostics page/panel.
+2. Confirm current Mirror transport for WebGL.
+3. Validate WSS deployment.
+4. Create WebGL smoke test scene.
+5. Test iOS Safari early.
+
+If current Mirror + WebSocket works on iOS Safari, do not migrate networking yet. Clean it first.

--- a/WEBGL_PREFLIGHT_STATIC_REVIEW.md
+++ b/WEBGL_PREFLIGHT_STATIC_REVIEW.md
@@ -1,0 +1,211 @@
+# WebGL preflight static review
+
+Static review performed from the repository before opening/running the Unity project.
+
+## What can be checked from the repo
+
+This review can inspect committed configuration and source files. It cannot actually build or run WebGL, and it cannot reproduce iOS Safari runtime behavior. Those still require Unity + real browser/device testing.
+
+## Confirmed project baseline
+
+- Unity version: `2021.3.4f1`.
+- Active build scene: `Assets/Scenes/MONGLICLIENT.unity`.
+- WebGL build settings exist in `ProjectSettings/ProjectSettings.asset`.
+- Mirror scripting define symbols are present for both Standalone and WebGL.
+- Mirror is embedded under `Assets/Mirror`.
+- Mirror `SimpleWebTransport` exists in the repository.
+
+## WebGL settings observed
+
+From `ProjectSettings/ProjectSettings.asset`:
+
+```text
+webGLMemorySize: 32
+webGLExceptionSupport: 1
+webGLNameFilesAsHashes: 0
+webGLDataCaching: 1
+webGLTemplate: APPLICATION:Default
+webGLCompressionFormat: 1
+webGLThreadsSupport: 0
+webGLDecompressionFallback: 1
+```
+
+### Assessment
+
+#### Good
+
+- `webGLDataCaching: 1` is useful for repeated browser loads.
+- `webGLDecompressionFallback: 1` makes hosting more forgiving if compressed content headers are not perfect.
+- `webGLThreadsSupport: 0` avoids requiring cross-origin isolation headers, which simplifies browser/mobile deployment.
+- Mirror symbols are enabled for WebGL.
+
+#### Risk / suspicious
+
+- `webGLMemorySize: 32` is very low for a Unity 3D game. This may be especially problematic on iOS Safari if the initial scene/assets are not tiny.
+- `webGLTemplate: APPLICATION:Default` means there is no custom WebGL template currently visible in settings. This makes it harder to add diagnostics, mobile loading UX, user-agent checks, audio unlock handling and friendly error overlays.
+- `webGLNameFilesAsHashes: 0` is fine for development, but production cache behavior should be reviewed.
+- Compression is enabled. Final hosting must serve correct MIME and `Content-Encoding` headers, especially for `.wasm`, `.data`, `.js`, `.gz` or `.br` files.
+
+## Networking findings
+
+`Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs` exists and defines:
+
+```csharp
+public const string NormalScheme = "ws";
+public const string SecureScheme = "wss";
+```
+
+This is good for browser compatibility because WebGL clients should use WebSocket/WSS, not raw UDP/TCP.
+
+### Still not confirmed
+
+The repository contains SimpleWebTransport, but this static review has **not confirmed** that the active scene/network manager is actually using it.
+
+Need to verify in Unity:
+
+- Which `Transport` component is attached to the active NetworkManager.
+- Whether the active transport is `SimpleWebTransport`.
+- Whether WebGL builds use `clientUseWss = true` or SSL/reverse-proxy setup.
+- Which port and hostname are used.
+- Whether native/headless server and WebGL browser client use compatible transport settings.
+
+## iOS/browser risk areas
+
+### 1. Memory
+
+`webGLMemorySize: 32` should be treated as a red flag until tested.
+
+Recommended next test values:
+
+```text
+Development smoke test: 128 MB
+Gameplay test: 256 MB or more, depending on actual build size/assets
+Production: smallest stable value after device testing
+```
+
+Do not blindly increase memory too much for iOS because mobile Safari may reject large allocations. The right value must be found by testing.
+
+### 2. No custom WebGL shell
+
+Because the project uses the default template, there is no committed project-level place for:
+
+- browser diagnostics;
+- `Tap to start` overlay;
+- audio unlock;
+- WebSocket/WSS endpoint display;
+- build version/commit display;
+- friendly unsupported-browser messages.
+
+Recommendation:
+
+Create a custom WebGL template or a separate diagnostics page before serious mobile testing.
+
+### 3. Fullscreen
+
+There is an old WebGL fullscreen plugin in the project history, but this static review has not confirmed current active usage.
+
+On iOS, true fullscreen behavior can be unreliable. Gameplay should not depend on fullscreen being available.
+
+### 4. Touch input
+
+The project uses Unity Input System and has an old Input System on-screen controls sample in build settings, disabled.
+
+Need to verify:
+
+- Current active control path for mobile.
+- Whether touch controls are in the active scene.
+- Whether page scroll/zoom is prevented in the WebGL shell.
+
+## Recommended immediate checks in Unity
+
+### Check 1 - Confirm active transport
+
+Open `MONGLICLIENT.unity` and find the NetworkManager object.
+
+Confirm:
+
+```text
+Transport component = SimpleWebTransport
+WebGL client connects through ws/wss
+Production uses wss:// when page is served over https://
+```
+
+### Check 2 - Increase WebGL memory for smoke test
+
+For testing only, try:
+
+```text
+WebGL Memory Size: 128 MB
+```
+
+Then test iOS Safari early. If it fails, test both lower and higher values with a tiny scene.
+
+### Check 3 - Create a WebGL smoke scene
+
+Make a tiny scene that tests only:
+
+```text
+Unity loads
+Tap input works
+Audio unlock works
+WSS connects
+One local object moves
+One server echo or round-trip works
+```
+
+### Check 4 - Add diagnostics before game load
+
+Add a diagnostics page or custom template that checks:
+
+```text
+WebGL 1
+WebGL 2
+WebAssembly
+WebSocket
+AudioContext
+Touch support
+Pointer events
+Fullscreen API
+IndexedDB/localStorage
+DevicePixelRatio
+Viewport size
+User Agent
+```
+
+## Proposed safe repo changes before manual testing
+
+### Option A - Docs only
+
+Keep current PR documentation and manually test in Unity.
+
+### Option B - Add standalone diagnostics page
+
+Add a file outside Unity runtime, for example:
+
+```text
+Tools/WebGLDiagnostics/diagnostics.html
+```
+
+This can be opened from any browser/device before running the Unity build.
+
+### Option C - Add custom WebGL template
+
+Create:
+
+```text
+Assets/WebGLTemplates/MongliDiagnostics/
+```
+
+This is more integrated but should be done carefully because it changes build output behavior.
+
+## Current recommendation
+
+Before changing networking or Unity versions:
+
+1. Confirm active Mirror transport in Unity.
+2. Validate `SimpleWebTransport` with WebGL.
+3. Test iOS Safari with a tiny smoke scene.
+4. Increase WebGL memory from `32 MB` for testing.
+5. Add a diagnostics shell/page.
+
+If Mirror + SimpleWebTransport works through `wss://` on iOS Safari, keep it for now and clean the architecture before considering NGO/FishNet/Photon.


### PR DESCRIPTION
## Summary

Adds a study for updating Unity/package versions and evaluating networking options while preserving current functionality.

## Covers

- Current Unity/package baseline.
- Risks of upgrading Unity and networking at the same time.
- Conservative Unity 2021 LTS upgrade path.
- Unity 6 compatibility path.
- Mirror cleanup vs migration.
- Netcode for GameObjects, Fish-Networking and Photon Fusion evaluation.
- Prototype plan and branch roadmap.

## Recommendation

Do not migrate networking immediately. First stabilize the current Mirror-based project, document the active player runtime map, then test Unity/package upgrades and networking candidates in isolated branches/prototypes.