### PR TITLE
refactor: add Unity API client layer

### DIFF
--- a/Assets/_Project/Scripts/API/ApiException.cs
+++ b/Assets/_Project/Scripts/API/ApiException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace ElTesoroDeMongli.API
+{
+    public class ApiException : Exception
+    {
+        public long StatusCode { get; }
+        public int? ErrorCode { get; }
+        public string ResponseBody { get; }
+
+        public ApiException(string message, long statusCode = 0, int? errorCode = null, string responseBody = null) : base(message)
+        {
+            StatusCode = statusCode;
+            ErrorCode = errorCode;
+            ResponseBody = responseBody;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/API/IAuthApiClient.cs
+++ b/Assets/_Project/Scripts/API/IAuthApiClient.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using ElTesoroDeMongli.API.Models;
+
+namespace ElTesoroDeMongli.API
+{
+    public interface IAuthApiClient
+    {
+        Task<LoginResponse> LoginAsync(LoginRequest request);
+        Task<RegisterResponse> RegisterAsync(RegisterRequest request);
+    }
+}

--- a/Assets/_Project/Scripts/API/IUserApiClient.cs
+++ b/Assets/_Project/Scripts/API/IUserApiClient.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using ElTesoroDeMongli.API.Models;
+
+namespace ElTesoroDeMongli.API
+{
+    public interface IUserApiClient
+    {
+        Task<GetUsersResponse> GetUsersAsync();
+        Task<UpdateUsersResponse> UpdateUsersAsync(UpdateUsersRequest request);
+    }
+}

--- a/Assets/_Project/Scripts/API/Models/ApiResponse.cs
+++ b/Assets/_Project/Scripts/API/Models/ApiResponse.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ElTesoroDeMongli.API.Models
+{
+    [Serializable]
+    public class ApiResponse
+    {
+        public int error_code;
+
+        public bool IsSuccess => error_code == 0;
+    }
+}

--- a/Assets/_Project/Scripts/API/Models/AuthModels.cs
+++ b/Assets/_Project/Scripts/API/Models/AuthModels.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace ElTesoroDeMongli.API.Models
+{
+    [Serializable]
+    public class LoginRequest
+    {
+        public string mail;
+        public string password;
+
+        public LoginRequest(string mail, string password)
+        {
+            this.mail = mail;
+            this.password = password;
+        }
+    }
+
+    [Serializable]
+    public class RegisterRequest
+    {
+        public string mail;
+        public string password;
+        public string nickname;
+
+        public RegisterRequest(string mail, string password, string nickname)
+        {
+            this.mail = mail;
+            this.password = password;
+            this.nickname = nickname;
+        }
+    }
+
+    [Serializable]
+    public class LoginResponse : ApiResponse
+    {
+        public LoginContent content;
+    }
+
+    [Serializable]
+    public class LoginContent
+    {
+        public int user_id;
+        public string token;
+    }
+
+    [Serializable]
+    public class RegisterResponse : ApiResponse
+    {
+    }
+}

--- a/Assets/_Project/Scripts/API/Models/UserModels.cs
+++ b/Assets/_Project/Scripts/API/Models/UserModels.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ElTesoroDeMongli.API.Models
+{
+    [Serializable]
+    public class UserTransformData
+    {
+        public Vector3 position;
+        public Quaternion rotation;
+    }
+
+    [Serializable]
+    public class UserDto
+    {
+        public int id;
+        public string nickname;
+        public UserTransformData transform;
+    }
+
+    [Serializable]
+    public class GetUsersResponse : ApiResponse
+    {
+        public List<UserDto> content;
+    }
+
+    [Serializable]
+    public class UpdateUsersRequest
+    {
+        public List<UserUpdateData> usersUpdateData = new List<UserUpdateData>();
+    }
+
+    [Serializable]
+    public class UserUpdateData
+    {
+        public int id;
+        public UserTransformData transform;
+    }
+
+    [Serializable]
+    public class UpdateUsersResponse : ApiResponse
+    {
+    }
+}

--- a/Assets/_Project/Scripts/API/PhpApiClient.cs
+++ b/Assets/_Project/Scripts/API/PhpApiClient.cs
@@ -1,0 +1,87 @@
+using System.Text;
+using System.Threading.Tasks;
+using ElTesoroDeMongli.API.Models;
+using ElTesoroDeMongli.Config;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace ElTesoroDeMongli.API
+{
+    public class PhpApiClient : IAuthApiClient, IUserApiClient
+    {
+        private readonly EnvironmentConfig config;
+
+        public PhpApiClient(EnvironmentConfig config)
+        {
+            this.config = config;
+        }
+
+        public Task<LoginResponse> LoginAsync(LoginRequest request)
+        {
+            return PostAsync<LoginRequest, LoginResponse>("login/", request);
+        }
+
+        public Task<RegisterResponse> RegisterAsync(RegisterRequest request)
+        {
+            return PostAsync<RegisterRequest, RegisterResponse>("register/", request);
+        }
+
+        public Task<GetUsersResponse> GetUsersAsync()
+        {
+            return PostAsync<object, GetUsersResponse>("get_users/", new EmptyRequest());
+        }
+
+        public Task<UpdateUsersResponse> UpdateUsersAsync(UpdateUsersRequest request)
+        {
+            return PostAsync<UpdateUsersRequest, UpdateUsersResponse>("update_users/", request);
+        }
+
+        private async Task<TResponse> PostAsync<TRequest, TResponse>(string endpoint, TRequest request)
+            where TResponse : ApiResponse
+        {
+            if (config == null)
+                throw new ApiException("API config is null.");
+
+            string url = config.ApiBaseUrl + endpoint;
+            string json = JsonUtility.ToJson(request);
+            byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
+
+            using (UnityWebRequest webRequest = new UnityWebRequest(url, UnityWebRequest.kHttpVerbPOST))
+            {
+                webRequest.uploadHandler = new UploadHandlerRaw(bodyRaw);
+                webRequest.downloadHandler = new DownloadHandlerBuffer();
+                webRequest.SetRequestHeader("Content-Type", "application/json");
+                webRequest.SetRequestHeader("Accept", "application/json");
+
+                await webRequest.SendWebRequest();
+
+                string responseBody = webRequest.downloadHandler?.text;
+
+                if (webRequest.result != UnityWebRequest.Result.Success)
+                {
+                    throw new ApiException(
+                        $"API request failed: {webRequest.error}",
+                        webRequest.responseCode,
+                        responseBody: responseBody);
+                }
+
+                TResponse response = JsonUtility.FromJson<TResponse>(responseBody);
+
+                if (response == null)
+                {
+                    throw new ApiException(
+                        "API returned an empty or invalid JSON response.",
+                        webRequest.responseCode,
+                        responseBody: responseBody);
+                }
+
+                return response;
+            }
+        }
+
+        [System.Serializable]
+        private class EmptyRequest
+        {
+        }
+    }
+}

--- a/Assets/_Project/Scripts/API/README.md
+++ b/Assets/_Project/Scripts/API/README.md
@@ -1,0 +1,44 @@
+# API client layer
+
+This folder contains the first centralized API client layer for the PHP API.
+
+## Current purpose
+
+Provide a single place for:
+
+```text
+login
+register
+get_users
+update_users
+```
+
+without scattering endpoint URLs and `UnityWebRequest` calls across gameplay/UI scripts.
+
+## Dependencies
+
+This layer depends on `EnvironmentConfig` for the API base URL.
+
+## Example usage
+
+```csharp
+EnvironmentConfig config = EnvironmentConfigProvider.Current;
+PhpApiClient apiClient = new PhpApiClient(config);
+SessionService sessionService = new SessionService();
+AuthService authService = new AuthService(apiClient, sessionService);
+
+LoginResponse response = await authService.LoginAsync("test@example.com", "Test1234!");
+
+if (response.IsSuccess)
+{
+    Debug.Log($"Logged in as user {sessionService.CurrentSession.UserId}");
+}
+else
+{
+    Debug.LogWarning($"Login failed with error {response.error_code}");
+}
+```
+
+## Next step
+
+Wire the existing login/register UI to `AuthService` after locating the current UI scripts in Unity.

--- a/Assets/_Project/Scripts/API/UnityWebRequestAwaiter.cs
+++ b/Assets/_Project/Scripts/API/UnityWebRequestAwaiter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.CompilerServices;
+using UnityEngine.Networking;
+
+namespace ElTesoroDeMongli.API
+{
+    public static class UnityWebRequestAwaiterExtensions
+    {
+        public static UnityWebRequestAsyncOperationAwaiter GetAwaiter(this UnityWebRequestAsyncOperation asyncOperation)
+        {
+            return new UnityWebRequestAsyncOperationAwaiter(asyncOperation);
+        }
+    }
+
+    public class UnityWebRequestAsyncOperationAwaiter : INotifyCompletion
+    {
+        private readonly UnityWebRequestAsyncOperation asyncOperation;
+        private Action continuation;
+
+        public UnityWebRequestAsyncOperationAwaiter(UnityWebRequestAsyncOperation asyncOperation)
+        {
+            this.asyncOperation = asyncOperation;
+            asyncOperation.completed += OnCompleted;
+        }
+
+        public bool IsCompleted => asyncOperation.isDone;
+
+        public void GetResult()
+        {
+        }
+
+        public void OnCompleted(Action continuation)
+        {
+            this.continuation = continuation;
+        }
+
+        private void OnCompleted(AsyncOperation operation)
+        {
+            continuation?.Invoke();
+        }
+    }
+}

--- a/Assets/_Project/Scripts/API/UnityWebRequestAwaiter.cs
+++ b/Assets/_Project/Scripts/API/UnityWebRequestAwaiter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using UnityEngine;
 using UnityEngine.Networking;
 
 namespace ElTesoroDeMongli.API

--- a/Assets/_Project/Scripts/Auth/AuthService.cs
+++ b/Assets/_Project/Scripts/Auth/AuthService.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using ElTesoroDeMongli.API;
+using ElTesoroDeMongli.API.Models;
+
+namespace ElTesoroDeMongli.Auth
+{
+    public class AuthService
+    {
+        private readonly IAuthApiClient apiClient;
+        private readonly SessionService sessionService;
+
+        public AuthService(IAuthApiClient apiClient, SessionService sessionService)
+        {
+            this.apiClient = apiClient;
+            this.sessionService = sessionService;
+        }
+
+        public async Task<LoginResponse> LoginAsync(string login, string password)
+        {
+            LoginResponse response = await apiClient.LoginAsync(new LoginRequest(login, password));
+
+            if (response.IsSuccess && response.content != null)
+            {
+                sessionService.SetSession(new UserSession(
+                    response.content.user_id,
+                    response.content.token,
+                    login));
+            }
+
+            return response;
+        }
+
+        public Task<RegisterResponse> RegisterAsync(string mail, string password, string nickname)
+        {
+            return apiClient.RegisterAsync(new RegisterRequest(mail, password, nickname));
+        }
+
+        public void Logout()
+        {
+            sessionService.ClearSession();
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Auth/SessionService.cs
+++ b/Assets/_Project/Scripts/Auth/SessionService.cs
@@ -1,0 +1,18 @@
+namespace ElTesoroDeMongli.Auth
+{
+    public class SessionService
+    {
+        public UserSession CurrentSession { get; private set; }
+        public bool IsAuthenticated => CurrentSession != null && CurrentSession.IsAuthenticated;
+
+        public void SetSession(UserSession session)
+        {
+            CurrentSession = session;
+        }
+
+        public void ClearSession()
+        {
+            CurrentSession = null;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Auth/UserSession.cs
+++ b/Assets/_Project/Scripts/Auth/UserSession.cs
@@ -1,0 +1,18 @@
+namespace ElTesoroDeMongli.Auth
+{
+    public class UserSession
+    {
+        public int UserId { get; }
+        public string Token { get; }
+        public string Login { get; }
+
+        public bool IsAuthenticated => UserId > 0 && !string.IsNullOrWhiteSpace(Token);
+
+        public UserSession(int userId, string token, string login)
+        {
+            UserId = userId;
+            Token = token;
+            Login = login;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a centralized Unity API client/auth/session layer for the current PHP API.

## Branch stacking

This branch is based on `refactor/unity-environment-config` because it depends on `EnvironmentConfig`.

Merge order:

1. PR #17 - `refactor: add Unity environment config`
2. This PR - `refactor: add Unity API client layer`

## Changes

- Add API response/auth/user models.
- Add `IAuthApiClient` and `IUserApiClient`.
- Add `PhpApiClient` using `UnityWebRequest`.
- Add `ApiException`.
- Add awaiter support for `UnityWebRequestAsyncOperation`.
- Add `UserSession`, `SessionService`, and `AuthService`.
- Add usage notes.

## What this does not do yet

- Does not modify existing UI.
- Does not change existing login/register screens.
- Does not touch scenes or prefabs.
- Does not replace existing gameplay networking.

## Next step

Open Unity, locate the current login/register UI scripts, then wire them to `AuthService` in a separate PR.